### PR TITLE
fix crash when resource does not have any products

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -405,7 +405,7 @@ local function get_resource_icon(resource_prototype)
   if resource_prototype.mineable_properties == nil then
     return nil
   end
-  for _, product in ipairs(resource_prototype.mineable_properties.products) do
+  for _, product in ipairs(resource_prototype.mineable_properties.products or {}) do
     return {
       type = product.type,
       name = product.name,


### PR DESCRIPTION
A resource with no products crashes the mod, this fixes the problem (example, bitumen-seep in pypetroleumhandling (alpha), https://github.com/pyanodon/pypetroleumhandling/blob/master/prototypes/ores/bitumen-seep.lua)